### PR TITLE
logger middleware updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage.out
+example/example

--- a/example/main.go
+++ b/example/main.go
@@ -12,9 +12,8 @@ import (
 
 func main() {
 	log.SetFlags(log.Lshortfile)
-	router := mux.NewRouter()
+	router := mux.NewRouter(slog.Default())
 	router.Use(mux.Logger)
-	router.SetLogger(slog.Default())
 	router.Get("/{$}", page)
 	router.Post("/hello", hello)
 	router.HandleFunc("GET /junk", junk)

--- a/middleware.go
+++ b/middleware.go
@@ -3,6 +3,7 @@ package mux
 import (
 	"log"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -21,11 +22,10 @@ func (rec *statusRecorder) WriteHeader(code int) {
 // Logger is a logging middleware that logs useragent, RemoteAddr, Method, Host, Path and response.Status to stdlib log.
 func Logger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Println("logger middleware")
 		now := time.Now()
 		rec := statusRecorder{w, http.StatusOK}
 		next.ServeHTTP(&rec, r)
-		remote := r.RemoteAddr
+		remote := strings.Split(r.RemoteAddr, ":")[0]
 		if r.Header.Get("X-Forwarded-For") != "" {
 			remote = r.Header.Get("X-Forwarded-For")
 		}

--- a/router.go
+++ b/router.go
@@ -31,8 +31,11 @@ func DefaultRouter() *Router {
 }
 
 // NewRouter creates a new Router with the given middleware applied.
-func NewRouter(middleware ...Middleware) *Router {
+func NewRouter(l *slog.Logger, middleware ...Middleware) *Router {
 	r := DefaultRouter()
+	if l != nil {
+		r.Logger = l
+	}
 	r.Use(middleware...)
 	return r
 }

--- a/router_bench_test.go
+++ b/router_bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkRouterBase(b *testing.B) {
 }
 
 func BenchmarkRouterWithOneMiddleware(b *testing.B) {
-	router := NewRouter(makeMiddleware("m1"))
+	router := NewRouter(nil, makeMiddleware("m1"))
 	router.HandleFunc("/bench", dummyHandler)
 
 	req := httptest.NewRequest("GET", "/bench", nil)

--- a/router_test.go
+++ b/router_test.go
@@ -2,6 +2,7 @@ package mux
 
 import (
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -35,7 +36,7 @@ func TestMiddlewareExecution(t *testing.T) {
 		})
 	}
 
-	router := NewRouter(middleware, Logger)
+	router := NewRouter(slog.Default(), middleware, Logger)
 	router.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "pong")
 	})


### PR DESCRIPTION
- trim port from r.RemoteAddr
- add slog.Logger param to  `NewRouter` function; if nil slog.DiscardLogger applied as before